### PR TITLE
Add a publishConfig section for GitHub Packages

### DIFF
--- a/.github/workflows/gpr_publish.yml
+++ b/.github/workflows/gpr_publish.yml
@@ -1,0 +1,28 @@
+name: Publish to GitHub Packages
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: npm ci
+
+  publish-gpr:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://npm.pkg.github.com/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "type": "git",
     "url": "https://github.com/kalwalt/jsartoolkitNFT"
   },
+  "publishConfig": {
+    "registry":"https://npm.pkg.github.com/"
+  },
   "homepage": "https://github.com/kalwalt/jsartoolkitNFT",
   "contributors": [
     "Github Contributors (https://github.com/kalwalt/jsartoolkitNFT/graphs/contributors)"


### PR DESCRIPTION
This will let `npm publish` know to publish on GitHub Packages.