### PR TITLE
Resolved videoLuma array size to scan whole the camera frame for marker detection

### DIFF
--- a/src/ARControllerNFT.ts
+++ b/src/ARControllerNFT.ts
@@ -862,7 +862,7 @@ export class ARControllerNFT implements AbstractARControllerNFT {
 
     this.framesize = this._width * this._height;
 
-    this.videoLuma = new Uint8Array(this.framesize / 4);
+    this.videoLuma = new Uint8Array(this.framesize);
 
     this.camera_mat = this.artoolkitNFT.getCameraLens();
 

--- a/src/ARControllerNFT_simd.ts
+++ b/src/ARControllerNFT_simd.ts
@@ -862,7 +862,7 @@ export class ARControllerNFT implements AbstractARControllerNFT {
 
     this.framesize = this._width * this._height;
 
-    this.videoLuma = new Uint8Array(this.framesize / 4);
+    this.videoLuma = new Uint8Array(this.framesize);
 
     this.camera_mat = this.artoolkitNFT.getCameraLens();
 

--- a/src/ARControllerNFT_td.ts
+++ b/src/ARControllerNFT_td.ts
@@ -862,7 +862,7 @@ export class ARControllerNFT implements AbstractARControllerNFT {
 
     this.framesize = this._width * this._height;
 
-    this.videoLuma = new Uint8Array(this.framesize / 4);
+    this.videoLuma = new Uint8Array(this.framesize);
 
     this.camera_mat = this.artoolkitNFT.getCameraLens();
 


### PR DESCRIPTION
The start of marker detection had an issue since a specific version. After digging into code and monitoring some variables, I realized that _videoLuma_ array size, is 1/4 of the size that it had to be. I think this division has happened 2 times from the main video frame, and this is causing the issue. In the _ARControllerNFT_ file at __copyImageToHeap_ function, _videoLuma_ get filled with values in the whole true size, but the size that is defined before, is a quarter of that. This caused the detection, only work at the first quarter of the video frame and it was not very performant.