### PR TITLE
fix(ci): fix CI commit step failure (issue #593)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,9 @@ name: Build jsartoolkitNFT CI
 on:
   push
 
+permissions:
+  contents: write
+
 jobs:
   build:
 
@@ -67,6 +70,7 @@ jobs:
         default_author: github_actions
         message: new build files from action
         add: '["build", "dist"]'
+        fetch: false
 
     - name: Release
       uses: softprops/action-gh-release@v3


### PR DESCRIPTION
## 1. PR Summary
- **Purpose**: Resolves CI workflow failure on commit stage (issue #593).
- **Key Metrics**: 1 file changed, 4 lines added.
- **Base Branch**: `dev`

## 2. Detailed Description
### The Problem
The CI workflow `.github/workflows/main.yml` fails during the "Commit changes" step using `EndBug/add-and-commit@v10`. The underlying library (`simple-git`) fails when parsing standard Git tag-fetching `stderr` output (which is outputted during `git fetch --tags --force`).

### The Solution
1. Set `fetch: false` in the `add-and-commit` step configuration to skip remote fetching.
2. Add `permissions: contents: write` at the workflow level to ensure the GITHUB_TOKEN has permission to write and push the commit.

## 3. Review Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tested the changes locally / verify configuration
- [x] Backwards compatibility maintained

## 4. Risk Assessment
- **Risk Level**: 🟢 Low
- **Details**: Very low impact as this only affects the CI environment during automated builds on push.
- **Mitigation**: Standard practice configuration options were used.

## 5. Test Coverage
- **Before**: N/A (CI config change)
- **After**: N/A (CI config change)

## 6. Visual Aids
N/A (Workflow configuration change)

## 7. Size Recommendations
Very small change (1 file, +4 lines). No splitting needed.

## 8. Review Automation
Validated the YAML file formatting and options locally.
